### PR TITLE
Lowercase myweatherhub in apphost project reference

### DIFF
--- a/complete/AppHost/Program.cs
+++ b/complete/AppHost/Program.cs
@@ -6,7 +6,7 @@ var cache = builder.AddRedis("cache")
 var api = builder.AddProject<Projects.Api>("api")
 	.WithReference(cache);
 
-var web = builder.AddProject<Projects.MyWeatherHub>("MyWeatherHub")
+var web = builder.AddProject<Projects.MyWeatherHub>("myweatherhub")
 	.WithReference(api);
 
 

--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -54,7 +54,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 	```csharp
 	var api = builder.AddProject<Projects.Api>("api");
 
-	var web = builder.AddProject<Projects.MyWeatherHub>("MyWeatherHub");
+	var web = builder.AddProject<Projects.MyWeatherHub>("myweatherhub");
 	```
 
 ## Run the application

--- a/workshop/4-servicediscovery.md
+++ b/workshop/4-servicediscovery.md
@@ -20,7 +20,7 @@ To address these issues, we will use the service discovery functionality provide
 	```csharp
 	var api = builder.AddProject<Projects.Api>("api");
 
-	var web = builder.AddProject<Projects.MyWeatherHub>("MyWeatherHub")
+	var web = builder.AddProject<Projects.MyWeatherHub>("myweatherhub")
 		.WithReference(api)
 		.WithExternalHttpEndpoints();
 	```


### PR DESCRIPTION
This pull request primarily includes changes to the project name in the `AddProject` method from "MyWeatherHub" to "myweatherhub" in three different files. This fixes a deployment error when publishing to ACA due to uppercase in project reference name.

Here are the key changes:

* [`complete/AppHost/Program.cs`](diffhunk://#diff-8df1b9607396c3636fe32157bd49f1acfa071b57912c997482c43bd1bb62c1daL9-R9): Changed the project name from "MyWeatherHub" to "myweatherhub" in the `AddProject` method.
* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192L57-R57): Updated the project name in the code snippet from "MyWeatherHub" to "myweatherhub".
* [`workshop/4-servicediscovery.md`](diffhunk://#diff-37f47a3713c84c2e1d22c93046827c7db9e6a7e1de262595b5ef65438d4ba8d3L23-R23): Modified the project name in the code snippet from "MyWeatherHub" to "myweatherhub".