### PR TITLE
Markdown updates for .NET 9

### DIFF
--- a/workshop/1-setup.md
+++ b/workshop/1-setup.md
@@ -2,8 +2,8 @@
 
 This workshop will be using the following tools:
 
-- [.NET 8 SDK](https://dot.net/download)
-- [.NET Aspire Workload](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling?tabs=dotnet-cli%2Cunix#install-net-aspire)
+- [.NET 9 SDK](https://get.dot.net/9)
+- OR [.NET 8 SDK](https://get.dot.net/8) with [.NET Aspire Workload](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling?tabs=dotnet-cli%2Cunix#install-net-aspire)
 - [Docker Desktop](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/getting-started/installation)
 - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) or [Visual Studio Code](https://code.visualstudio.com/) with [C# Dev Kit](https://code.visualstudio.com/docs/csharp/get-started)
 


### PR DESCRIPTION
This pull request includes an update to the `workshop/1-setup.md` file to reflect the latest versions of the .NET SDK and the .NET Aspire Workload. The most important changes include updating the links and instructions for the required tools.

Updates to tool requirements:

* [`workshop/1-setup.md`](diffhunk://#diff-ad9bb5c7688167e1340ac8054a1ad04f60b47fd09e10d1e4e16be9447a84aa6aL5-R6): Updated the .NET SDK requirement to include both .NET 9 SDK and .NET 8 SDK with .NET Aspire Workload, providing updated links for download.