### PR TITLE
Add links to next module at the end of each

### DIFF
--- a/workshop/1-setup.md
+++ b/workshop/1-setup.md
@@ -32,3 +32,5 @@ To test your installation, see the [Build your first .NET Aspire project](https:
 ## Open Workshop Start Solution
 
 To start the workshop open `start-with-api/MyWeatherHub.sln` in Visual Studio 2022. If you are using Visual Studio code open the `start-with-api` folder and when prompted by the C# Dev Kit which solution to open, select **MyWeatherHub.sln**.
+
+**Next**: [Module #2 - Service Defaults](2-servicedefaults.md)

--- a/workshop/2-servicedefaults.md
+++ b/workshop/2-servicedefaults.md
@@ -81,3 +81,5 @@
    Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
    System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
    ```
+
+**Next**: [Module #3 - Dashboard & App Host](3-dashboard-apphost.md)

--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -98,3 +98,5 @@ Before continuing, consider some common terminology used in .NET Aspire:
     ![.NET Aspire Dashboard](./media/dashboard-error.png)
 
 1. Click on the `Trace` or the `Details` to see the error message and stack trace.
+
+**Next**: [Module #4: Service Discovery](./4-servicediscovery.md)

--- a/workshop/4-servicediscovery.md
+++ b/workshop/4-servicediscovery.md
@@ -84,3 +84,5 @@ This was just the start of what we can do with service discovery and .NET Aspire
 ## Learn More
 
 You can learn more about advanced usage and configuration of service discovery in the [.NET Aspire Service Discovery](https://learn.microsoft.com/dotnet/aspire/service-discovery/overview) documentation.
+
+**Next**: [Module #5: Integrations](./5-integrations.md)

--- a/workshop/5-integrations.md
+++ b/workshop/5-integrations.md
@@ -124,3 +124,5 @@ In this section, we added a Redis hosting integration to the App Host and Redis 
 There are many more Aspire integrations available that you can use to integrate with your services. You can find the list of available integrations [in the .NET Aspire documentation](https://learn.microsoft.com/dotnet/aspire/fundamentals/integrations-overview?tabs=dotnet-cli#available-integrations).
 
 A natural next step would be to integrate a database or leverage Azure Redis Cache as a hosted solution. Integrations for these and more are [available on NuGet](https://www.nuget.org/packages?q=owner%3Aaspire+tags%3Aintegration).
+
+**Next**: [Module #6: Deployment](6-deployment.md)


### PR DESCRIPTION
This pull request includes updates to the workshop documentation for the .NET Aspire project. The changes add navigation links to guide users through the workshop modules in a sequential manner.

Documentation improvements:

* [`workshop/1-setup.md`](diffhunk://#diff-ad9bb5c7688167e1340ac8054a1ad04f60b47fd09e10d1e4e16be9447a84aa6aR35-R36): Added a link to proceed to Module 2 - Service Defaults.
* [`workshop/2-servicedefaults.md`](diffhunk://#diff-a87cd8f4abfa125227312b42a585c62f56066be45cdee2a8be9e7433f64af404R84-R85): Added a link to proceed to Module 3 - Dashboard & App Host.
* [`workshop/3-dashboard-apphost.md`](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192R101-R102): Added a link to proceed to Module 4 - Service Discovery.
* [`workshop/4-servicediscovery.md`](diffhunk://#diff-37f47a3713c84c2e1d22c93046827c7db9e6a7e1de262595b5ef65438d4ba8d3R87-R88): Added a link to proceed to Module 5 - Integrations.
* [`workshop/5-integrations.md`](diffhunk://#diff-af5332b1adb55065f871f169eb45badb01ea40877461bd08ec029975eef3f345R127-R128): Added a link to proceed to Module 6 - Deployment.