### PR TITLE
Bump NuGet packages

### DIFF
--- a/complete/Api/Api.csproj
+++ b/complete/Api/Api.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />

--- a/complete/MyWeatherHub/MyWeatherHub.csproj
+++ b/complete/MyWeatherHub/MyWeatherHub.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="9.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/complete/ServiceDefaults/ServiceDefaults.csproj
+++ b/complete/ServiceDefaults/ServiceDefaults.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
   </ItemGroup>
 </Project>

--- a/start-with-api/Api/Api.csproj
+++ b/start-with-api/Api/Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 </Project>

--- a/start-with-api/MyWeatherHub/MyWeatherHub.csproj
+++ b/start-with-api/MyWeatherHub/MyWeatherHub.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="9.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request includes updates to various package references across multiple project files to ensure they are using the latest versions. The changes primarily focus on upgrading dependencies to improve security, performance, and compatibility.

Dependency upgrades:

* [`complete/Api/Api.csproj`](diffhunk://#diff-cfba2519c37dea96e3cdef13398d5b0ab32feb86955bc75de07884e1697ac3fcL9-R10): Updated `Microsoft.AspNetCore.OpenApi` to version 9.0.2 and `Swashbuckle.AspNetCore` to version 7.2.0.
* [`complete/MyWeatherHub/MyWeatherHub.csproj`](diffhunk://#diff-d840c52b750a129801414f5d72d01df009c54f903f806296532a6916b9d07cd4L8-R9): Updated `Microsoft.AspNetCore.Components.QuickGrid` and `Microsoft.Extensions.ApiDescription.Client` to version 9.0.2.
* [`complete/ServiceDefaults/ServiceDefaults.csproj`](diffhunk://#diff-5c07c10758cebd7adaa5ba60b405e1e3fba09c828cce36faf5c57acc10d174ceL10-R16): Updated `Microsoft.Extensions.Http.Resilience` to version 9.2.0, `OpenTelemetry.Exporter.OpenTelemetryProtocol` and `OpenTelemetry.Extensions.Hosting` to version 1.11.1, and `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`, and `OpenTelemetry.Instrumentation.Runtime` to version 1.11.0.
* [`start-with-api/Api/Api.csproj`](diffhunk://#diff-b57210ece53795987a399dc760d075f7d7d98ae977403e3003827f35c6696c1eL8-R9): Updated `Microsoft.AspNetCore.OpenApi` to version 9.0.2 and `Swashbuckle.AspNetCore` to version 7.2.0.
* [`start-with-api/MyWeatherHub/MyWeatherHub.csproj`](diffhunk://#diff-8ae14113891fc13233ba207dbf416439343e77a49aa4c1c421d168b9891384c9L8-R9): Updated `Microsoft.AspNetCore.Components.QuickGrid` and `Microsoft.Extensions.ApiDescription.Client` to version 9.0.2.