### PR TITLE
Improve zones.json for deployment

### DIFF
--- a/complete/Api/Api.csproj
+++ b/complete/Api/Api.csproj
@@ -12,4 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\zones.json" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #43

Embed `zones.json` as a resource and modify code to read it.

* **Api.csproj**
  - Add `zones.json` as an embedded resource.

* **NwsManager.cs**
  - Modify `GetZonesAsync` method to read `zones.json` as an embedded resource instead of from the `wwwroot` folder.
  - Remove the `webHostEnvironment` parameter from the `NwsManager` constructor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet-presentations/dotnet-aspire-workshop/pull/64?shareId=f891a849-5dc3-437f-b70c-0075e256da64).