### PR TITLE
Add integration testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also watch the Let's Learn .NET Aspire live stream events for the follow
 
 ## Workshop
 
-This .NET Aspire workshop is part of the [Let's Learn .NET](https://aka.ms/letslearndotnet) series.  This workshop is designed to help you learn about .NET Aspire and how to use it to build cloud ready applications.  This workshop is broken down into 8 modules:
+This .NET Aspire workshop is part of the [Let's Learn .NET](https://aka.ms/letslearndotnet) series.  This workshop is designed to help you learn about .NET Aspire and how to use it to build cloud ready applications.  This workshop is broken down into 9 modules:
 
 1. [Setup & Installation](./workshop/1-setup.md)
 1. [Service Defaults](./workshop/2-servicedefaults.md)
@@ -54,6 +54,7 @@ This .NET Aspire workshop is part of the [Let's Learn .NET](https://aka.ms/letsl
 1. [Deployment](./workshop/6-deployment.md)
 1. [Telemetry Module](./workshop/7-telemetry.md)
 1. [Database Module](./workshop/8-database.md)
+1. [Integration Testing](./workshop/9-integration-testing.md)
 
 A full slide deck is available for this workshop [here](./workshop/AspireWorkshop.pptx).
 

--- a/complete/Api/Api.csproj
+++ b/complete/Api/Api.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Tests\IntegrationTests.csproj" />
   </ItemGroup>
 </Project>

--- a/complete/Api/Tests/IntegrationTests.cs
+++ b/complete/Api/Tests/IntegrationTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Api.Tests
+{
+    [TestClass]
+    public class IntegrationTests
+    {
+        private static readonly HttpClient client = new HttpClient();
+
+        [TestMethod]
+        public async Task TestGetZonesAsync()
+        {
+            var response = await client.GetAsync("https://localhost:7032/zones");
+            response.EnsureSuccessStatusCode();
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.IsNotNull(responseBody);
+            Assert.IsTrue(responseBody.Contains("ZoneId"));
+        }
+
+        [TestMethod]
+        public async Task TestGetForecastByZoneAsync()
+        {
+            var response = await client.GetAsync("https://localhost:7032/forecast/AKZ318");
+            response.EnsureSuccessStatusCode();
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.IsNotNull(responseBody);
+            Assert.IsTrue(responseBody.Contains("DetailedForecast"));
+        }
+    }
+}

--- a/complete/MyWeatherHub/MyWeatherHub.csproj
+++ b/complete/MyWeatherHub/MyWeatherHub.csproj
@@ -14,5 +14,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Tests\IntegrationTests.csproj" />
   </ItemGroup>
 </Project>

--- a/complete/MyWeatherHub/Tests/IntegrationTests.cs
+++ b/complete/MyWeatherHub/Tests/IntegrationTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace MyWeatherHub.Tests
+{
+    [TestClass]
+    public class IntegrationTests
+    {
+        private static readonly HttpClient client = new HttpClient();
+
+        [TestMethod]
+        public async Task TestHomePageAsync()
+        {
+            var response = await client.GetAsync("https://localhost:7274/");
+            response.EnsureSuccessStatusCode();
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.IsNotNull(responseBody);
+            Assert.IsTrue(responseBody.Contains("My Weather Hub"));
+        }
+
+        [TestMethod]
+        public async Task TestGetForecastByZoneAsync()
+        {
+            var response = await client.GetAsync("https://localhost:7274/forecast/AKZ318");
+            response.EnsureSuccessStatusCode();
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.IsNotNull(responseBody);
+            Assert.IsTrue(responseBody.Contains("DetailedForecast"));
+        }
+    }
+}

--- a/start-with-api/Api/Api.csproj
+++ b/start-with-api/Api/Api.csproj
@@ -8,4 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tests\IntegrationTests.csproj" />
+  </ItemGroup>
 </Project>

--- a/start-with-api/MyWeatherHub/MyWeatherHub.csproj
+++ b/start-with-api/MyWeatherHub/MyWeatherHub.csproj
@@ -11,4 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tests\IntegrationTests.csproj" />
+  </ItemGroup>
 </Project>

--- a/workshop/9-integration-testing.md
+++ b/workshop/9-integration-testing.md
@@ -1,0 +1,163 @@
+# Integration Testing with .NET Aspire
+
+## Introduction
+
+In this module, we will cover integration testing using `Aspire.Hosting.Testing` with `MSTest`. Integration testing is crucial for ensuring that different parts of your application work together as expected. We will also explain the difference between unit testing and integration testing in the context of distributed applications with .NET Aspire.
+
+## Unit Testing vs. Integration Testing
+
+### Unit Testing
+
+Unit testing focuses on testing individual components or units of code in isolation. The goal is to verify that each unit of code behaves as expected. Unit tests are typically fast and do not depend on external systems or resources.
+
+### Integration Testing
+
+Integration testing, on the other hand, focuses on testing the interactions between different components or systems. The goal is to ensure that the integrated components work together as expected. Integration tests may involve external systems, databases, APIs, and other resources.
+
+In the context of distributed applications with .NET Aspire, integration testing is essential for verifying that different services and components can communicate and function correctly in a real-world environment.
+
+## Setting Up Integration Testing
+
+### Adding the Test Project
+
+1. Create a new test project in your solution:
+   - Right-click on the solution and select `Add` > `New Project`.
+   - Select the `MSTest Test Project` template.
+   - Name the project `IntegrationTests`.
+   - Click `Next` > `Create`.
+
+2. Install the required NuGet packages in the `IntegrationTests` project:
+
+   ```bash
+   dotnet add package Aspire.Hosting.Testing
+   dotnet add package MSTest.TestAdapter
+   dotnet add package MSTest.TestFramework
+   ```
+
+### Configuring the Test Project
+
+1. Add references to the `Api` and `MyWeatherHub` projects in the `IntegrationTests` project:
+   - Right-click on the `IntegrationTests` project and select `Add` > `Reference`.
+   - Check the `Api` and `MyWeatherHub` projects and click `OK`.
+
+2. Create a new file `IntegrationTestBase.cs` in the `IntegrationTests` project:
+
+   ```csharp
+   using Aspire.Hosting.Testing;
+   using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+   [TestClass]
+   public abstract class IntegrationTestBase
+   {
+       protected static AspireTestHost TestHost;
+
+       [AssemblyInitialize]
+       public static void AssemblyInitialize(TestContext context)
+       {
+           TestHost = AspireTestHost.CreateBuilder()
+               .AddProject<Projects.Api>("api")
+               .AddProject<Projects.MyWeatherHub>("myweatherhub")
+               .Build();
+       }
+
+       [AssemblyCleanup]
+       public static void AssemblyCleanup()
+       {
+           TestHost.Dispose();
+       }
+   }
+   ```
+
+## Writing Integration Tests
+
+### API Integration Tests
+
+1. Create a new file `ApiIntegrationTests.cs` in the `IntegrationTests` project:
+
+   ```csharp
+   using Microsoft.VisualStudio.TestTools.UnitTesting;
+   using System.Net.Http;
+   using System.Threading.Tasks;
+
+   [TestClass]
+   public class ApiIntegrationTests : IntegrationTestBase
+   {
+       private static HttpClient _client;
+
+       [ClassInitialize]
+       public static void ClassInitialize(TestContext context)
+       {
+           _client = TestHost.GetHttpClient("api");
+       }
+
+       [TestMethod]
+       public async Task GetForecast_ReturnsSuccess()
+       {
+           var response = await _client.GetAsync("/forecast/AKZ018");
+           response.EnsureSuccessStatusCode();
+           var content = await response.Content.ReadAsStringAsync();
+           Assert.IsNotNull(content);
+       }
+   }
+   ```
+
+### Web Application Integration Tests
+
+1. Create a new file `WebAppIntegrationTests.cs` in the `IntegrationTests` project:
+
+   ```csharp
+   using Microsoft.VisualStudio.TestTools.UnitTesting;
+   using System.Net.Http;
+   using System.Threading.Tasks;
+
+   [TestClass]
+   public class WebAppIntegrationTests : IntegrationTestBase
+   {
+       private static HttpClient _client;
+
+       [ClassInitialize]
+       public static void ClassInitialize(TestContext context)
+       {
+           _client = TestHost.GetHttpClient("myweatherhub");
+       }
+
+       [TestMethod]
+       public async Task HomePage_ReturnsSuccess()
+       {
+           var response = await _client.GetAsync("/");
+           response.EnsureSuccessStatusCode();
+           var content = await response.Content.ReadAsStringAsync();
+           Assert.IsNotNull(content);
+       }
+   }
+   ```
+
+## Running the Tests
+
+1. Run the tests using the Test Explorer in Visual Studio or the `dotnet test` command:
+
+   ```bash
+   dotnet test IntegrationTests
+   ```
+
+2. Verify that all tests pass successfully.
+
+## Playwright for End-to-End Testing
+
+Playwright is a powerful tool for end-to-end testing of web applications. It allows you to automate browser interactions and verify the behavior of your application from the user's perspective. Playwright supports multiple browsers, including Chromium, Firefox, and WebKit.
+
+### Use Cases for Playwright
+
+- **User Interface Testing**: Verify that the UI elements are rendered correctly and respond to user interactions.
+- **Cross-Browser Testing**: Ensure that your application works consistently across different browsers.
+- **End-to-End Testing**: Test the entire workflow of your application, from the frontend to the backend.
+
+### Getting Started with Playwright
+
+To get started with Playwright, refer to the official documentation: [Playwright for .NET](https://playwright.dev/dotnet/)
+
+## Conclusion
+
+In this module, we covered the basics of integration testing using `Aspire.Hosting.Testing` with `MSTest`. We also introduced Playwright for end-to-end testing. Integration testing is crucial for ensuring that different parts of your application work together as expected, especially in distributed applications with .NET Aspire.
+
+**Next**: [Module #10: Advanced Topics](10-advanced-topics.md)


### PR DESCRIPTION
Fixes #72

Add a module for integration testing using `Aspire.Hosting.Testing` with `MSTest`.

* **New Module**: Add `workshop/9-integration-testing.md` to explain the difference between unit testing and integration testing, provide a test project for both API and web application, and introduce Playwright for end-to-end testing.
* **README Update**: Update `README.md` to include the new "Integration Testing" module in the list of workshop modules.
* **Project References**: Add references to the new test project in `start-with-api/Api/Api.csproj`, `start-with-api/MyWeatherHub/MyWeatherHub.csproj`, `complete/Api/Api.csproj`, and `complete/MyWeatherHub/MyWeatherHub.csproj`.
* **Integration Tests**: Add `complete/Api/Tests/IntegrationTests.cs` and `complete/MyWeatherHub/Tests/IntegrationTests.cs` to create test classes for integration tests of the API and web application, respectively.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet-presentations/dotnet-aspire-workshop/pull/73?shareId=cd135d62-3db7-4fad-8389-25c257eee21f).