### PR TITLE
Remove .NET Aspire workload from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,7 @@
         },
         "ghcr.io/azure/azure-dev/azd:latest": {},
         "ghcr.io/devcontainers/features/dotnet:2": {
-            "version": "none",
-            "workloads": "aspire"
+            "version": "none"
         }
     },
     "customizations": {


### PR DESCRIPTION
No longer needed since .NET Aspire no longer is installed as a workload