### PR TITLE
Add OpenTelemetry instrumentation for ASP.NET Core

### DIFF
--- a/complete/ServiceDefaults/ServiceDefaults.csproj
+++ b/complete/ServiceDefaults/ServiceDefaults.csproj
@@ -9,6 +9,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
+	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />


### PR DESCRIPTION
This commit adds a new package reference for
`OpenTelemetry.Instrumentation.AspNetCore` version `1.11.1` to the `ServiceDefaults.csproj` file. This enhancement improves the application's observability by enabling instrumentation for ASP.NET Core applications using OpenTelemetry.