### PR TITLE
Update for .NET 9 template change from Swagger to OpenAPI

### DIFF
--- a/complete/Api/Program.cs
+++ b/complete/Api/Program.cs
@@ -27,6 +27,11 @@ app.MapDefaultEndpoints();
 
 app.UseHttpsRedirection();
 
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
 // Map the endpoints for the API
 app.MapApiEndpoints();
 

--- a/complete/Api/Properties/launchSettings.json
+++ b/complete/Api/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22045"
@@ -15,7 +15,7 @@
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
@@ -27,7 +27,7 @@
     "Container (.NET SDK)": {
       "commandName": "SdkContainer",
       "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/openapi/v1.json",
       "environmentVariables": {
         "ASPNETCORE_HTTPS_PORTS": "8081",
         "ASPNETCORE_HTTP_PORTS": "8080"

--- a/start/Api/Program.cs
+++ b/start/Api/Program.cs
@@ -18,6 +18,11 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
 // Map the endpoints for the API
 app.MapApiEndpoints();
 

--- a/start/Api/Properties/launchSettings.json
+++ b/start/Api/Properties/launchSettings.json
@@ -4,9 +4,10 @@
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22045"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5271"
@@ -14,9 +15,11 @@
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22126"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7032;http://localhost:5271"
@@ -24,7 +27,7 @@
     "Container (.NET SDK)": {
       "commandName": "SdkContainer",
       "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/openapi/v1.json",
       "environmentVariables": {
         "ASPNETCORE_HTTPS_PORTS": "8081",
         "ASPNETCORE_HTTP_PORTS": "8080"


### PR DESCRIPTION
Update for .NET 9 template change from Swagger to OpenAPI

- Added conditional mapping for OpenAPI endpoints in `Program.cs` for development mode.
- Updated `launchUrl` in `launchSettings.json` from "swagger" to "openapi/v1.json" for `http`, `https`, and `Container (.NET SDK)` profiles.
- Included `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` in environment variables for better resource service configuration during development.