### PR TITLE
Remove Swagger from the API projects (using OpenAPI instead)

### DIFF
--- a/complete/Api/Program.cs
+++ b/complete/Api/Program.cs
@@ -25,12 +25,12 @@ var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
-app.UseHttpsRedirection();
-
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
+
+app.UseHttpsRedirection();
 
 // Map the endpoints for the API
 app.MapApiEndpoints();

--- a/start/Api/Program.cs
+++ b/start/Api/Program.cs
@@ -12,16 +12,10 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
 }
 
 app.UseHttpsRedirection();
-
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
 
 // Map the endpoints for the API
 app.MapApiEndpoints();


### PR DESCRIPTION
This pull request includes changes to the `Program.cs` files in both the `complete/Api` and `start/Api` directories to improve the configuration of the HTTP request pipeline. The most important changes involve reordering middleware and consolidating the Swagger setup.

Changes to `complete/Api/Program.cs`:

* Moved `app.UseHttpsRedirection()` to be after the development environment check.

Changes to `start/Api/Program.cs`:

* Consolidated the Swagger setup by using `app.MapOpenApi()` within the development environment check and removed redundant code.