### PR TITLE
Remove Swashbuckle NuGet pkg

### DIFF
--- a/start/Api/Api.csproj
+++ b/start/Api/Api.csproj
@@ -6,6 +6,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes a small change to the `start/Api/Api.csproj` file. The change removes the `Swashbuckle.AspNetCore` package reference. 

* [`start/Api/Api.csproj`](diffhunk://#diff-8ee0b3cc585e6de20e3211da15762725aeb48143b3c0b7a01dfe769b4e6064f0L9): Removed `Swashbuckle.AspNetCore` package reference.