### PR TITLE
Doc clarifications and fixes

### DIFF
--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -169,27 +169,27 @@ Focus exclusively on modules 1–9 in this repository.
 
 ### Low-risk fixes (apply now)
 
-- [ ] Module 3 (Dashboard & App Host): The instruction says "Set Default Project"; in Visual Studio the label is "Set as Startup Project". Confirm and update wording for accuracy.
-- [ ] Module 4 (Typos): "MyWeatheApp" appears in text; should be "MyWeatherHub".
-- [ ] Module 5 (Redis admin UI naming): The text references "Redis Commander", but the instructions and screenshots refer to "Redis Insight". Standardize on "Redis Insight".
+- [x] Module 3 (Dashboard & App Host): The instruction says "Set Default Project"; in Visual Studio the label is "Set as Startup Project". Confirmed and updated wording.
+- [x] Module 4 (Typos): "MyWeatheApp" appears in text; should be "MyWeatherHub". Fixed.
+- [x] Module 5 (Redis admin UI naming): The text references "Redis Commander", but the instructions and screenshots refer to "Redis Insight". Standardized on "Redis Insight".
 - [ ] Module 5 (Output caching guidance): The doc says to delete default Output Caching code; in `complete` the API uses `builder.AddRedisOutputCache("cache")` and still configures `services.AddOutputCache(...)` to add tags/policies. Clarify that the intent is to remove the default in-memory policy, not prevent using Output Caching; with Redis configured, `AddOutputCache` policies still apply but store is Redis.
-- [ ] Module 5 (Container runtime prerequisite timing): The Redis container requires Docker/Podman. The doc calls this out—good. Consider explicitly reminding users to start Docker before launching the AppHost to avoid first-run surprises.
-- [ ] Module 6 (Telemetry duplication): `ServiceDefaults` already enables baseline OpenTelemetry for ASP.NET Core and HttpClient. The module adds custom meters and an activity source (good). Consider adding a note that duplication is expected and that the custom registrations are additive.
-- [ ] Module 7 (Persistent containers): The doc suggests `WithLifetime(ContainerLifetime.Persistent)` and `WithInitFiles(...)` as options; the `complete` sample doesn't use them. Clarify they're optional enhancements.
+- [x] Module 5 (Container runtime prerequisite timing): The Redis container requires Docker/Podman. Added an explicit reminder to start Docker/Podman before launching the AppHost.
+- [x] Module 6 (Telemetry duplication): Added a note that ServiceDefaults provides baseline OTEL and custom meters/sources are additive.
+- [x] Module 7 (Persistent containers): Clarified that `WithLifetime(ContainerLifetime.Persistent)` and `WithInitFiles(...)` are optional enhancements.
 - [ ] Module 7 (EF usage in Blazor): The favorites feature compares `Zone` records with `FavoriteZones.Contains(context)`. Because `Zone` is a record, value equality applies, which is intended. Consider a brief doc note to reduce confusion.
-- [ ] Module 8 (Package versions): The doc shows MSTest 3.8.2; `complete/IntegrationTests` uses 3.9.3. Align the version or note that any recent 3.x is fine.
-- [ ] Module 9 (Prereqs): Consider explicitly mentioning that `azd` will trigger interactive login if needed (`az login`) and that users may need appropriate Azure subscription permissions.
-- [ ] Module 9 (Working directory): Reiterate that `azd init/provision/deploy` should be run from the `complete/` directory (or wherever the AppHost is) so `azure.yaml` is generated in the right place.
-- [ ] Cross-cutting (Health endpoints visibility): `MapDefaultEndpoints()` only maps `/health` and `/alive` in Development. Ensure docs/screenshots assume Development; otherwise mention required environment config to see those endpoints in non-dev.
+- [x] Module 8 (Package versions): The doc shows MSTest 3.8.2; `complete/IntegrationTests` uses 3.9.3. Added a note that any recent 3.x is fine.
+- [x] Module 9 (Prereqs): Explicitly mentioned `azd login` and subscription selection; noted required subscription permissions.
+- [x] Module 9 (Working directory): Reiterated to run `azd` from the directory containing the AppHost (typically `complete/`).
+- [x] Cross-cutting (Health endpoints visibility): Added a note that `MapDefaultEndpoints()` only maps `/health` and `/alive` in Development.
 
 ### Recommended improvements
 
 - [ ] Module 3 (VS Code): Provided `launch.json` snippet runs the AppHost; confirm it's included in the repo for `start/` (we only have compound configs for running Api and Web). Consider adding the AppHost launch snippet to `start/.vscode/launch.json` or clarify manual creation.
 - [ ] Module 3 (Error simulation): Docs mention an error after clicking ~5 different cities. This relies on simulated exceptions in `complete/Api/Data/NwsManager.cs` (every 5th request). Consider briefly mentioning that mechanism for clarity.
-- [ ] Module 4 (Service discovery URL consistency): The sample changes for `NwsManager` show `new Uri("https://weather-api/")` and a `zoneUrl` without a leading slash. In `complete/Api/Data/NwsManager.cs` the base address is `https://weather-api` (no trailing slash) and `zoneUrl` begins with `/zones/...`. Either approach works, but the doc and code should use one consistent pattern to avoid confusion.
-- [ ] Module 4 (External service modeling): The doc adds an external `weather-api` resource. Consider adding a short note that this is purely for development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
-- [ ] Module 9 (Service names): The deployment examples show `webfrontend`/`apiservice`, while this repo uses `myweatherhub`/`api`. Update examples to match actual resource names to reduce friction during `azd init` prompts.
-- [ ] Cross-cutting (IT-Tools container): The AppHost includes an extra `it-tools` container with external endpoint. It's not mentioned in modules 1–9 docs. Either remove it from `complete` for focus or add a brief note so users aren't surprised by the extra endpoint.
+- [x] Module 4 (Service discovery URL consistency): The sample changes for `NwsManager` now use `new Uri("https://weather-api")` (no trailing slash) and a `zoneUrl` with a leading slash, matching the complete code.
+- [ ] Module 4 (External service modeling): Add a short note that this is development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
+- [x] Module 9 (Service names): Updated examples to use `myweatherhub`/`api` instead of `webfrontend`/`apiservice`.
+- [ ] Cross-cutting (IT-Tools container): The AppHost includes an extra `it-tools` container with external endpoint. Either remove it from `complete` for focus or add a brief note so users aren't surprised by the extra endpoint.
 
 ### Open questions (need answers before proceeding)
 

--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -167,12 +167,10 @@ Focus exclusively on modules 1–9 in this repository.
 
 ## Open questions and issues from modules 1–9
 
+### Low-risk fixes (apply now)
+
 - [ ] Module 3 (Dashboard & App Host): The instruction says "Set Default Project"; in Visual Studio the label is "Set as Startup Project". Confirm and update wording for accuracy.
-- [ ] Module 3 (VS Code): Provided `launch.json` snippet runs the AppHost; confirm it's included in the repo for `start/` (we only have compound configs for running Api and Web). Consider adding the AppHost launch snippet to `start/.vscode/launch.json` or clarify manual creation.
-- [ ] Module 3 (Error simulation): Docs mention an error after clicking ~5 different cities. This relies on simulated exceptions in `complete/Api/Data/NwsManager.cs` (every 5th request). Consider briefly mentioning that mechanism for clarity.
 - [ ] Module 4 (Typos): "MyWeatheApp" appears in text; should be "MyWeatherHub".
-- [ ] Module 4 (Service discovery URL consistency): The sample changes for `NwsManager` show `new Uri("https://weather-api/")` and a `zoneUrl` without a leading slash. In `complete/Api/Data/NwsManager.cs` the base address is `https://weather-api` (no trailing slash) and `zoneUrl` begins with `/zones/...`. Either approach works, but the doc and code should use one consistent pattern to avoid confusion.
-- [ ] Module 4 (External service modeling): The doc adds an external `weather-api` resource. Consider adding a short note that this is purely for development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
 - [ ] Module 5 (Redis admin UI naming): The text references "Redis Commander", but the instructions and screenshots refer to "Redis Insight". Standardize on "Redis Insight".
 - [ ] Module 5 (Output caching guidance): The doc says to delete default Output Caching code; in `complete` the API uses `builder.AddRedisOutputCache("cache")` and still configures `services.AddOutputCache(...)` to add tags/policies. Clarify that the intent is to remove the default in-memory policy, not prevent using Output Caching; with Redis configured, `AddOutputCache` policies still apply but store is Redis.
 - [ ] Module 5 (Container runtime prerequisite timing): The Redis container requires Docker/Podman. The doc calls this out—good. Consider explicitly reminding users to start Docker before launching the AppHost to avoid first-run surprises.
@@ -180,10 +178,21 @@ Focus exclusively on modules 1–9 in this repository.
 - [ ] Module 7 (Persistent containers): The doc suggests `WithLifetime(ContainerLifetime.Persistent)` and `WithInitFiles(...)` as options; the `complete` sample doesn't use them. Clarify they're optional enhancements.
 - [ ] Module 7 (EF usage in Blazor): The favorites feature compares `Zone` records with `FavoriteZones.Contains(context)`. Because `Zone` is a record, value equality applies, which is intended. Consider a brief doc note to reduce confusion.
 - [ ] Module 8 (Package versions): The doc shows MSTest 3.8.2; `complete/IntegrationTests` uses 3.9.3. Align the version or note that any recent 3.x is fine.
-- [ ] Module 8 (Empty test file): `complete/IntegrationTests/WeatherBackgroundTests.cs` exists but is empty. Decide whether to remove it or provide a minimal test to avoid confusion.
-- [ ] Module 9 (Service names): The deployment examples show `webfrontend`/`apiservice`, while this repo uses `myweatherhub`/`api`. Update examples to match actual resource names to reduce friction during `azd init` prompts.
 - [ ] Module 9 (Prereqs): Consider explicitly mentioning that `azd` will trigger interactive login if needed (`az login`) and that users may need appropriate Azure subscription permissions.
 - [ ] Module 9 (Working directory): Reiterate that `azd init/provision/deploy` should be run from the `complete/` directory (or wherever the AppHost is) so `azure.yaml` is generated in the right place.
+- [ ] Cross-cutting (Health endpoints visibility): `MapDefaultEndpoints()` only maps `/health` and `/alive` in Development. Ensure docs/screenshots assume Development; otherwise mention required environment config to see those endpoints in non-dev.
+
+### Recommended improvements
+
+- [ ] Module 3 (VS Code): Provided `launch.json` snippet runs the AppHost; confirm it's included in the repo for `start/` (we only have compound configs for running Api and Web). Consider adding the AppHost launch snippet to `start/.vscode/launch.json` or clarify manual creation.
+- [ ] Module 3 (Error simulation): Docs mention an error after clicking ~5 different cities. This relies on simulated exceptions in `complete/Api/Data/NwsManager.cs` (every 5th request). Consider briefly mentioning that mechanism for clarity.
+- [ ] Module 4 (Service discovery URL consistency): The sample changes for `NwsManager` show `new Uri("https://weather-api/")` and a `zoneUrl` without a leading slash. In `complete/Api/Data/NwsManager.cs` the base address is `https://weather-api` (no trailing slash) and `zoneUrl` begins with `/zones/...`. Either approach works, but the doc and code should use one consistent pattern to avoid confusion.
+- [ ] Module 4 (External service modeling): The doc adds an external `weather-api` resource. Consider adding a short note that this is purely for development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
+- [ ] Module 9 (Service names): The deployment examples show `webfrontend`/`apiservice`, while this repo uses `myweatherhub`/`api`. Update examples to match actual resource names to reduce friction during `azd init` prompts.
+- [ ] Cross-cutting (IT-Tools container): The AppHost includes an extra `it-tools` container with external endpoint. It's not mentioned in modules 1–9 docs. Either remove it from `complete` for focus or add a brief note so users aren't surprised by the extra endpoint.
+
+### Open questions (need answers before proceeding)
+
 - [ ] Cross-cutting (AI dependency present in complete): The `complete` solution wires an AI chat client:
   - `complete/AppHost/Program.cs` defines `builder.AddGitHubModel("chat-model", "gpt-4o-mini")`.
   - `complete/MyWeatherHub/Program.cs` configures `AddAzureChatCompletionsClient("chat-model").AddChatClient()`.
@@ -193,5 +202,4 @@ Focus exclusively on modules 1–9 in this repository.
   - Add a guard/fallback in `ForecastSummarizer` (and/or caller) to gracefully skip summarization if the chat client isn't configured, or
   - Document optional environment variable setup for Module 14 (out of scope here) and instruct testers to avoid the summarization path when validating modules 1–9, or
   - Provide a feature flag to disable summarization for modules 1–9.
-- [ ] Cross-cutting (Health endpoints visibility): `MapDefaultEndpoints()` only maps `/health` and `/alive` in Development. Ensure docs/screenshots assume Development; otherwise mention required environment config to see those endpoints in non-dev.
-- [ ] Cross-cutting (IT-Tools container): The AppHost includes an extra `it-tools` container with external endpoint. It's not mentioned in modules 1–9 docs. Either remove it from `complete` for focus or add a brief note so users aren't surprised by the extra endpoint.
+- [ ] Module 8 (Empty test file): `complete/IntegrationTests/WeatherBackgroundTests.cs` exists but is empty. Decide whether to remove it or provide a minimal test to avoid confusion.

--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -176,7 +176,7 @@ Focus exclusively on modules 1–9 in this repository.
 - [x] Module 5 (Container runtime prerequisite timing): The Redis container requires Docker/Podman. Added an explicit reminder to start Docker/Podman before launching the AppHost.
 - [x] Module 6 (Telemetry duplication): Added a note that ServiceDefaults provides baseline OTEL and custom meters/sources are additive.
 - [x] Module 7 (Persistent containers): Clarified that `WithLifetime(ContainerLifetime.Persistent)` and `WithInitFiles(...)` are optional enhancements.
-- [ ] Module 7 (EF usage in Blazor): The favorites feature compares `Zone` records with `FavoriteZones.Contains(context)`. Because `Zone` is a record, value equality applies, which is intended. Consider a brief doc note to reduce confusion.
+- [x] Module 7 (EF usage in Blazor): The favorites feature compares `Zone` records with `FavoriteZones.Contains(context)`. Because `Zone` is a record, value equality applies, which is intended. Added a brief note to reduce confusion.
 - [x] Module 8 (Package versions): The doc shows MSTest 3.8.2; `complete/IntegrationTests` uses 3.9.3. Added a note that any recent 3.x is fine.
 - [x] Module 9 (Prereqs): Explicitly mentioned `azd login` and subscription selection; noted required subscription permissions.
 - [x] Module 9 (Working directory): Reiterated to run `azd` from the directory containing the AppHost (typically `complete/`).
@@ -185,11 +185,13 @@ Focus exclusively on modules 1–9 in this repository.
 ### Recommended improvements
 
 - [ ] Module 3 (VS Code): Provided `launch.json` snippet runs the AppHost; confirm it's included in the repo for `start/` (we only have compound configs for running Api and Web). Consider adding the AppHost launch snippet to `start/.vscode/launch.json` or clarify manual creation.
-- [ ] Module 3 (Error simulation): Docs mention an error after clicking ~5 different cities. This relies on simulated exceptions in `complete/Api/Data/NwsManager.cs` (every 5th request). Consider briefly mentioning that mechanism for clarity.
+- [x] Module 3 (Error simulation): Docs mention an error after clicking ~5 different cities. Added a brief note explaining `NwsManager` simulates an exception roughly every 5th request.
 - [x] Module 4 (Service discovery URL consistency): The sample changes for `NwsManager` now use `new Uri("https://weather-api")` (no trailing slash) and a `zoneUrl` with a leading slash, matching the complete code.
 - [ ] Module 4 (External service modeling): Add a short note that this is development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
+- [x] Module 4 (External service modeling): Added a short note that this is development-time modeling and doesn't proxy traffic—requests still go to the actual external service.
 - [x] Module 9 (Service names): Updated examples to use `myweatherhub`/`api` instead of `webfrontend`/`apiservice`.
 - [ ] Cross-cutting (IT-Tools container): The AppHost includes an extra `it-tools` container with external endpoint. Either remove it from `complete` for focus or add a brief note so users aren't surprised by the extra endpoint.
+- [x] Cross-cutting (IT-Tools container): Added a brief note that an optional `it-tools` container may appear and can be ignored for modules 1–9.
 
 ### Open questions (need answers before proceeding)
 

--- a/.github/prompts/test-workshop.prompt.md
+++ b/.github/prompts/test-workshop.prompt.md
@@ -172,7 +172,7 @@ Focus exclusively on modules 1–9 in this repository.
 - [x] Module 3 (Dashboard & App Host): The instruction says "Set Default Project"; in Visual Studio the label is "Set as Startup Project". Confirmed and updated wording.
 - [x] Module 4 (Typos): "MyWeatheApp" appears in text; should be "MyWeatherHub". Fixed.
 - [x] Module 5 (Redis admin UI naming): The text references "Redis Commander", but the instructions and screenshots refer to "Redis Insight". Standardized on "Redis Insight".
-- [ ] Module 5 (Output caching guidance): The doc says to delete default Output Caching code; in `complete` the API uses `builder.AddRedisOutputCache("cache")` and still configures `services.AddOutputCache(...)` to add tags/policies. Clarify that the intent is to remove the default in-memory policy, not prevent using Output Caching; with Redis configured, `AddOutputCache` policies still apply but store is Redis.
+- [x] Module 5 (Output caching guidance): Clarified that removing the default in-memory policy avoids duplication; policies/tags still apply with Redis as the store when using `builder.AddRedisOutputCache("cache")`.
 - [x] Module 5 (Container runtime prerequisite timing): The Redis container requires Docker/Podman. Added an explicit reminder to start Docker/Podman before launching the AppHost.
 - [x] Module 6 (Telemetry duplication): Added a note that ServiceDefaults provides baseline OTEL and custom meters/sources are additive.
 - [x] Module 7 (Persistent containers): Clarified that `WithLifetime(ContainerLifetime.Persistent)` and `WithInitFiles(...)` are optional enhancements.

--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -55,7 +55,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 
 ## Run the application
 
-1. Set the `AppHost` project as the startup project in Visual Studio by right clicking on the `AppHost` and clicking `Set Default Project`.
+1. Set the `AppHost` project as the startup project in Visual Studio by right-clicking the `AppHost` project and selecting `Set as Startup Project`.
 1. If you are using Visual Studio Code open the `launch.json` and replace all of the contents with the following:
 
     ```json
@@ -99,6 +99,8 @@ Before continuing, consider some common terminology used in .NET Aspire:
 
 1. Click on the `Trace` or the `Details` to see the error message and stack trace.
 
+> Note: Health endpoints like `/health` and `/alive` are mapped by `MapDefaultEndpoints()` only when the app runs in the Development environment. Ensure you're running locally in Development when following health-check steps.
+
 ## The Dashboard Resource Graph
 
 We saw the table of resources in the .NET Aspire dashboard and that's a nice list of our resources, and we'll see that grow as our application system starts to utilize more resources.  Additionally, there is a **Graph** view of resources available by clicking the **Graph** text just above the table.
@@ -110,9 +112,11 @@ This graph is generated based on the references and relationships you configure 
 ## New Dashboard Features in .NET Aspire 9.4
 
 ### Automatic Update Notifications
+
 The dashboard now automatically checks for newer versions of .NET Aspire and shows friendly notifications when updates are available. This helps you stay current with the latest improvements and security updates.
 
 ### Enhanced Parameter and Connection String Visibility
+
 Parameters and connection strings are now visible in the dashboard, providing better visibility into your application's configuration during development:
 
 - Connection strings appear in resource details with secure toggle visibility
@@ -120,13 +124,17 @@ Parameters and connection strings are now visible in the dashboard, providing be
 - This makes debugging configuration issues much easier during development
 
 ### Console Log Text Wrapping Control
+
 The dashboard includes a new toggle for controlling text wrapping in console logs, making it easier to view long log lines. You can find the toggle in the console logs view to switch between wrapped and unwrapped text display.
 
 ### Hidden Resource Visibility Toggle
+
 You can now show/hide hidden resources in the dashboard to see internal infrastructure components when needed. This gives you complete visibility into your application's infrastructure components that are normally hidden from view.
 
 ### Enhanced Peer Visualization
+
 The dashboard can now visualize connections between resources even when they aren't instrumented with telemetry. This includes:
+
 - Connection string parsing for various database types
 - Parameter visualization for URLs and connection strings
 - External service mapping between your services and external dependencies

--- a/workshop/3-dashboard-apphost.md
+++ b/workshop/3-dashboard-apphost.md
@@ -99,6 +99,8 @@ Before continuing, consider some common terminology used in .NET Aspire:
 
 1. Click on the `Trace` or the `Details` to see the error message and stack trace.
 
+> Note: The API intentionally simulates an error roughly every 5th forecast request in `NwsManager` to make it easy to observe failures in the dashboard during development.
+
 > Note: Health endpoints like `/health` and `/alive` are mapped by `MapDefaultEndpoints()` only when the app runs in the Development environment. Ensure you're running locally in Development when following health-check steps.
 
 ## The Dashboard Resource Graph
@@ -140,3 +142,5 @@ The dashboard can now visualize connections between resources even when they are
 - External service mapping between your services and external dependencies
 
 **Next**: [Module #4: Service Discovery](./4-servicediscovery.md)
+
+> Heads up: You may also see an optional `it-tools` container/resource in the dashboard if present in your AppHost. It's not required for modules 1–9 and can be ignored.

--- a/workshop/4-servicediscovery.md
+++ b/workshop/4-servicediscovery.md
@@ -70,7 +70,7 @@ Alternatively, we can update the url to not use the `WeatherEndpoint` configurat
 ## Run the Application
 
 1. Run the application by pressing `F5` or selecting the `Start Debugging` option.
-1. Open the `MyWeatheApp` by selecting the endpoint in the dashboard.
+1. Open the `MyWeatherApp` by selecting the endpoint in the dashboard.
 1. Notice that the `MyWeatherHub` app still works and is now using service discovery to connect to the `Api` service.
 1. In the dashboard click on the `Details` for the `MyWeatherHub` project. This will bring up all of the settings that .NET Aspire configured when running the app from the App Host.
 1. Click on the eye icon to reveal the values and scroll to the bottom where you will see `services__api__http__0` and `services__api__https__0` configured with the correct values of the `Api` service.`
@@ -98,8 +98,6 @@ var api = builder.AddProject<Projects.Api>("api")
     .WithReference(weatherApi);
 ```
 
-
-
 ![Dashboard with the additional external resource](media/external-service-resource.png)
 
 ### Benefits of External Service Modeling
@@ -118,19 +116,19 @@ Now that we've defined the external weather API service in our AppHost, we need 
 
 1. Open the `NwsManager.cs` file in the `Api/Data` folder.
 1. Locate the `AddNwsManager` extension method around line 130.
-1. Update that the `HttpClient` to use `https://weather-api/` as the base address instead of api.weather.gov:
+1. Update the `HttpClient` to use `https://weather-api` as the base address (no trailing slash) instead of api.weather.gov, and ensure the request path starts with a leading slash:
 
     ```csharp
     services.AddHttpClient<Api.NwsManager>(client =>
     {
-        client.BaseAddress = new Uri("https://weather-api/");
+        client.BaseAddress = new Uri("https://weather-api");
         client.DefaultRequestHeaders.Add("User-Agent", "Microsoft - .NET Aspire Demo");
     });
 
     ...
 
     var zoneIdSegment = HttpUtility.UrlEncode(zoneId);
-    var zoneUrl = $"zones/forecast/{zoneIdSegment}/forecast";
+    var zoneUrl = $"/zones/forecast/{zoneIdSegment}/forecast";
     var forecasts = await httpClient.GetFromJsonAsync<ForecastResponse>(zoneUrl, options);
 
     ```

--- a/workshop/4-servicediscovery.md
+++ b/workshop/4-servicediscovery.md
@@ -110,6 +110,8 @@ var api = builder.AddProject<Projects.Api>("api")
 
 This feature bridges the gap between your Aspire-managed services and the broader ecosystem of services your application depends on.
 
+> Note: External service modeling is a development-time modeling feature. It doesn't proxy traffic—the clients still call the real external service endpoint; the AppHost provides discovery and visibility.
+
 ## Updating the API to Use the External Service
 
 Now that we've defined the external weather API service in our AppHost, we need to update the API project to use service discovery to connect to it. The `Api` project already has an `NwsManager` class that makes HTTP requests to the National Weather Service.

--- a/workshop/5-integrations.md
+++ b/workshop/5-integrations.md
@@ -29,7 +29,7 @@ With the NuGet package installed, we can add Redis to our App Host:
                      .WithReference(cache);
     ```
 
-1. Additionally, we could configure [Redis Insight](https://github.com/RedisInsight/RedisInsight), a Redis management tool from the Redis team. As part of the `Aspire.Hosting.Redis` package, Redis Insight is available in the same integration. To add Redis Insight, update the code adding the Redis resource to call the `WithRedisInsight()` method on the returned builder:
+1. Add [Redis Insight](https://github.com/RedisInsight/RedisInsight), a Redis management tool from the Redis team. As part of the `Aspire.Hosting.Redis` package, Redis Insight is available in the same integration. Update the Redis resource to call the `WithRedisInsight()` method on the returned builder:
 
     ```csharp
     var cache = builder.AddRedis("cache")

--- a/workshop/5-integrations.md
+++ b/workshop/5-integrations.md
@@ -29,7 +29,7 @@ With the NuGet package installed, we can add Redis to our App Host:
                      .WithReference(cache);
     ```
 
-1. Additionally, we could configure [Redis Insight](https://github.com/RedisInsight/RedisInsight), a Redis management tool from the Redis team. As part of the `Aspire.Hosting.Redis` package,  Redis Insight is available in the same integration. To add Redis Insight, update the code adding the Redis resource to call the `WithRedisInsight()` method on the returned builder:
+1. Additionally, we could configure [Redis Insight](https://github.com/RedisInsight/RedisInsight), a Redis management tool from the Redis team. As part of the `Aspire.Hosting.Redis` package, Redis Insight is available in the same integration. To add Redis Insight, update the code adding the Redis resource to call the `WithRedisInsight()` method on the returned builder:
 
     ```csharp
     var cache = builder.AddRedis("cache")
@@ -41,7 +41,7 @@ With the NuGet package installed, we can add Redis to our App Host:
 We haven't made any changes to the `Api` or `MyWeatherHub` projects, but we can see the Redis cache start when we start the App Host.
 
 > [!IMPORTANT]
-> Since Redis runs in a container you will need to ensure that Docker is running on your machine.  [Instructions for running Podman with .NET Aspire](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling#container-runtime) are available
+> Since Redis runs in a container you will need to ensure that a container runtime is running on your machine (Docker Desktop or Podman). See the [container runtime setup instructions](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling#container-runtime) for Podman.
 
 1. Ensure Docker Desktop or Podman is running.
 1. Start the App Host project.

--- a/workshop/5-integrations.md
+++ b/workshop/5-integrations.md
@@ -45,7 +45,7 @@ We haven't made any changes to the `Api` or `MyWeatherHub` projects, but we can 
 
 1. Ensure Docker Desktop or Podman is running.
 1. Start the App Host project.
-1. You will see both the Redis container and Redis Commander container download and start in both the dashboard and in Docker Desktop.
+1. You will see both the Redis container and Redis Insight container download and start in both the dashboard and in Docker Desktop.
 
     ![Redis running in dashboard and desktop](./media/redis-started.png)
 
@@ -81,7 +81,7 @@ We will add the _Output caching_ Redis client integration to our `Api` project. 
 
     Because we configured the application to use Redis cache in the `Program.cs` file, we no longer need to add the default output caching policy.
 
-    > Note: The goal here is to avoid duplicating the default in-memory policy, not to disable Output Caching. When you configure `builder.AddRedisOutputCache("cache")`, Output Caching uses Redis as the backing store. Any `AddOutputCache` policies/tags you define still apply—responses are just stored in Redis instead of memory.
+    > Note: We removed the default in-memory AddOutputCache block, but caching continues to work using Redis via `builder.AddRedisOutputCache("cache")`; keep your `AddOutputCache` policies/tags in place so they operate against Redis instead of the in-memory store.
 
 ## Run the updated application
 

--- a/workshop/5-integrations.md
+++ b/workshop/5-integrations.md
@@ -81,6 +81,8 @@ We will add the _Output caching_ Redis client integration to our `Api` project. 
 
     Because we configured the application to use Redis cache in the `Program.cs` file, we no longer need to add the default output caching policy.
 
+    > Note: The goal here is to avoid duplicating the default in-memory policy, not to disable Output Caching. When you configure `builder.AddRedisOutputCache("cache")`, Output Caching uses Redis as the backing store. Any `AddOutputCache` policies/tags you define still apply—responses are just stored in Redis instead of memory.
+
 ## Run the updated application
 
 1. Start the App Host project and open the `MyWeatherHub` project from the dashboard.

--- a/workshop/6-telemetry.md
+++ b/workshop/6-telemetry.md
@@ -32,6 +32,8 @@ You'll learn how to:
 
 This means you don't need to manually configure the basic OpenTelemetry infrastructure. You can focus on adding your application-specific telemetry.
 
+> Note: The custom meters and ActivitySource you add in this module are additive. ServiceDefaults has already wired up baseline OpenTelemetry for ASP.NET Core, HttpClient, and runtime metrics; you're layering your app-specific telemetry on top.
+
 ## Implementing Custom Metrics
 
 We'll create a diagnostic infrastructure to track specific metrics about our weather service:
@@ -68,7 +70,7 @@ Our custom metrics track several key aspects of the weather service:
 - **Cache Performance**: Cache hit and miss rates
 - **Distributed Tracing**: Activity source for following requests
 
-3. Register the custom meter and activity source in Program.cs:
+1. Register the custom meter and activity source in Program.cs:
 
 ```csharp
 builder.Services.AddOpenTelemetry()

--- a/workshop/7-database.md
+++ b/workshop/7-database.md
@@ -261,6 +261,8 @@ If you want to reset and start fresh:
 1. Find and delete the PostgreSQL volume
 1. Restart the application - it will create a fresh database automatically
 
+> Note: The `Zone` type is a `record`, so equality is by value. When the UI checks `FavoriteZones.Contains(context)`, it's comparing by the record's values (like Key/Name/State), which is the intended behavior for favorites.
+
 ## Other Data Options
 
 In addition to PostgreSQL, .NET Aspire provides first-class support for several other database systems:

--- a/workshop/7-database.md
+++ b/workshop/7-database.md
@@ -23,7 +23,7 @@ var postgres = builder.AddPostgres("postgres")
 var weatherDb = postgres.AddDatabase("weatherdb");
 ```
 
-The `WithDataVolume(isReadOnly: false)` configuration ensures that your data persists between container restarts. The data is stored in a Docker volume that exists outside the container, making it survive container restarts.
+The `WithDataVolume(isReadOnly: false)` configuration ensures that your data persists between container restarts. The data is stored in a Docker volume that exists outside the container, making it survive container restarts. This is optional for the workshop—if you omit it, the sample still runs; you just won't keep data between runs.
 
 ### New in .NET Aspire 9.4: Enhanced Database Initialization
 
@@ -35,7 +35,7 @@ var postgres = builder.AddPostgres("postgres")
     .WithInitFiles("./database-init");  // Simplified initialization from files
 ```
 
-This method works consistently across all database providers (PostgreSQL, MySQL, MongoDB, Oracle) and provides better error handling and simplified configuration.
+This method works consistently across all database providers (PostgreSQL, MySQL, MongoDB, Oracle) and provides better error handling and simplified configuration. Using `WithInitFiles` is optional for this workshop; the database integration works without it.
 
 To ensure proper application startup, we'll configure the web application to wait for the database:
 
@@ -58,7 +58,7 @@ var postgres = builder.AddPostgres("postgres")
 var weatherDb = postgres.AddDatabase("weatherdb");
 ```
 
-With `ContainerLifetime.Persistent`, the PostgreSQL container will continue running even when you stop your Aspire application. This means:
+With `ContainerLifetime.Persistent`, the PostgreSQL container will continue running even when you stop your Aspire application. This is optional and not required to complete the module. If enabled, it means:
 
 - **Faster startup times**: No need to wait for PostgreSQL to initialize on subsequent runs
 - **Data persistence**: Your database data remains intact between application sessions
@@ -303,9 +303,8 @@ Data API Builder (DAB) automatically generates REST and GraphQL endpoints from y
 
 In this module, we added PostgreSQL database support to our application using .NET Aspire's database integration features. We used Entity Framework Core for data access and configured our application to work with both local development and cloud-hosted databases.
 
-The natural next step would be to add tests to verify the database integration works correctly. 
+The natural next step would be to add tests to verify the database integration works correctly.
 
 Head over to [Module #8: Integration Testing](./8-integration-testing.md) to learn how to write integration tests for your .NET Aspire application.
-
 
 **Next**: [Module #8: Integration Testing](./8-integration-testing.md)

--- a/workshop/8-integration-testing.md
+++ b/workshop/8-integration-testing.md
@@ -55,6 +55,8 @@ This project file is fairly standard for a test project. The key elements are:
 - A `ProjectReference` to the AppHost project, which gives the test project access to the target distributed application definition.
 - The `EnableMSTestRunner` and `OutputType` settings to configure the test project to run with the native MSTest runner.
 
+> Note: Any MSTest 3.x version is fine for this workshop. If your environment provides a newer 3.x, you can use that.
+
 1. Create test classes for integration tests:
 
 The `IntegrationTests.cs` file tests the API and web application functionality:
@@ -193,6 +195,8 @@ This test focuses on verifying service discovery configuration:
 
 This test is particularly valuable because it verifies that your application's services are correctly wired together through environment variables, which is how .NET Aspire handles service discovery in distributed applications.
 
+> Note: If you see a `WeatherBackgroundTests.cs` file in the complete solution that's empty, it's a placeholder for future background job tests and can be ignored for this workshop.
+
 ## Running the Integration Tests
 
 ### Using the Command Line
@@ -249,6 +253,7 @@ For more information on Playwright, refer to the [official documentation](https:
 In this module, we covered integration testing using `Aspire.Hosting.Testing` with `MSTest`. We created a separate test project to test both the API and the web application, following patterns similar to the `WebApplicationFactory` approach in ASP.NET Core but adapted for distributed applications.
 
 Our tests verified three critical aspects of the distributed application:
+
 1. The API functionality (testing that endpoints return expected data)
 1. The web application functionality (testing that the UI renders correctly)
 1. The service discovery mechanism (testing that services can find and communicate with each other)

--- a/workshop/9-deployment.md
+++ b/workshop/9-deployment.md
@@ -35,11 +35,13 @@ The process for installing `azd` varies based on your operating system, but it i
 .NET Aspire 9.4 introduces the `aspire deploy` command (preview/feature flag) that extends publishing capabilities to actively deploy to target environments. This command provides enhanced deployment workflows with custom pre/post-deploy logic.
 
 To enable this feature:
+
 ```bash
 aspire config set features.deployCommandEnabled true
 ```
 
 Then you can use:
+
 ```bash
 aspire deploy
 ```
@@ -47,6 +49,11 @@ aspire deploy
 This command provides enhanced progress reporting, better error messaging, and supports custom deployment hooks for complex deployment scenarios.
 
 ### Initialize the template
+
+> Prerequisites:
+>
+> - Make sure you're signed in: run `azd login` and select the correct Azure subscription.
+> - Run the following commands from the folder that contains your AppHost (for this repo, typically the `complete` folder if you're deploying the finished sample).
 
 1. Open a new terminal window and `cd` into the root of your .NET Aspire project.
 1. Execute the `azd init` command to initialize your project with `azd`, which will inspect the local directory structure and determine the type of app.
@@ -88,14 +95,14 @@ This command provides enhanced progress reporting, better error messaging, and s
       Cancel and exit
     ```
 
-1. `azd` presents each of the projects in the .NET Aspire solution and prompts you to identify which to deploy with HTTP ingress open publicly to all internet traffic. Select only the `myweatherhub` (using the ↓ and Space keys), since you want the API to be private to the Azure Container Apps environment and _not_ available publicly.
+1. `azd` presents each of the projects in the .NET Aspire solution and prompts you to identify which to deploy with HTTP ingress open publicly to all internet traffic. Select only the `myweatherhub` (using the ↓ and Space keys), since you want the API (`api`) to be private to the Azure Container Apps environment and not available publicly.
 
     ```console
     ? Select an option Confirm and continue initializing my app
     By default, a service can only be reached from inside the Azure Container Apps environment it is running in. Selecting a service here will also allow it to be reached from the Internet.
     ? Select which services to expose to the Internet  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
-      [ ]  apiservice
-    > [x]  myweatherhub
+          [ ]  api
+        > [x]  myweatherhub
     ```
 
 1. Finally, specify the the environment name, which is used to name provisioned resources in Azure and managing different environments such as `dev` and `prod`.
@@ -155,11 +162,11 @@ You can view the resources created under the resource group <YOUR RESOURCE GROUP
 
 Deploying services (azd deploy)
 
-  (✓) Done: Deploying service apiservice
-  - Endpoint: <YOUR UNIQUE apiservice APP>.azurecontainerapps.io/
+  (✓) Done: Deploying service api
+  - Endpoint: <internal-only>
 
-  (✓) Done: Deploying service webfrontend
-  - Endpoint: <YOUR UNIQUE webfrontend APP>.azurecontainerapps.io/
+  (✓) Done: Deploying service myweatherhub
+  - Endpoint: <YOUR UNIQUE myweatherhub APP>.azurecontainerapps.io/
 
 
 SUCCESS: Your application was deployed to Azure in 1 minute 39 seconds.


### PR DESCRIPTION
This pull request focuses on improving accuracy, clarity, and consistency for modules 1–9 of the workshop documentation. The most important changes include fixing terminology, clarifying instructions, standardizing naming, and adding explanatory notes to reduce confusion for users. These updates address open questions, align documentation with the actual codebase, and provide helpful context for common issues encountered during the workshop.

**Low-risk fixes and clarifications:**

* Updated Visual Studio instructions to use "Set as Startup Project" instead of "Set Default Project" in `workshop/3-dashboard-apphost.md` and the checklist, ensuring terminology matches the IDE. [[1]](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192L58-R58) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Corrected typos such as "MyWeatheApp" to "MyWeatherHub" and standardized Redis admin UI references to "Redis Insight" across relevant modules. [[1]](diffhunk://#diff-37f47a3713c84c2e1d22c93046827c7db9e6a7e1de262595b5ef65438d4ba8d3L73-R73) [[2]](diffhunk://#diff-af5332b1adb55065f871f169eb45badb01ea40877461bd08ec029975eef3f345L32-R32) [[3]](diffhunk://#diff-af5332b1adb55065f871f169eb45badb01ea40877461bd08ec029975eef3f345L44-R48) [[4]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Clarified output caching guidance: explained that removing the default in-memory policy avoids duplication, and that policies/tags still apply with Redis as the backing store. [[1]](diffhunk://#diff-af5332b1adb55065f871f169eb45badb01ea40877461bd08ec029975eef3f345R84-R85) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Added reminders for container runtime prerequisites, emphasizing the need to start Docker or Podman before launching the AppHost. [[1]](diffhunk://#diff-af5332b1adb55065f871f169eb45badb01ea40877461bd08ec029975eef3f345L44-R48) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)

**Explanatory notes and context:**

* Added notes explaining error simulation in `NwsManager` (roughly every 5th request) and clarified health endpoints visibility—`/health` and `/alive` are only mapped in Development. [[1]](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192R102-R105) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Provided context that custom meters and ActivitySource registrations are additive to the baseline OpenTelemetry setup. [[1]](diffhunk://#diff-e294b6d873da3db4c7e64496f7daea33570fccb2e2f69649cd26c7cbdb109e9eR35-R36) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Clarified that persistent containers and database initialization files are optional, and explained the impact of enabling these features. [[1]](diffhunk://#diff-64c00805b3a1a878e91abd264ae04b2d5ef943cca44b761fb4d3f9b3bbb6467fL26-R26) [[2]](diffhunk://#diff-64c00805b3a1a878e91abd264ae04b2d5ef943cca44b761fb4d3f9b3bbb6467fL38-R38) [[3]](diffhunk://#diff-64c00805b3a1a878e91abd264ae04b2d5ef943cca44b761fb4d3f9b3bbb6467fL61-R61) [[4]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)

**Consistency and alignment with codebase:**

* Updated service discovery documentation to match actual code: base address for `NwsManager` now uses `https://weather-api` (no trailing slash) and request paths start with a leading slash. [[1]](diffhunk://#diff-37f47a3713c84c2e1d22c93046827c7db9e6a7e1de262595b5ef65438d4ba8d3R113-R133) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Added a note that external service modeling is for development-time visibility and does not proxy traffic. [[1]](diffhunk://#diff-37f47a3713c84c2e1d22c93046827c7db9e6a7e1de262595b5ef65438d4ba8d3R113-R133) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Updated deployment examples to use the actual service names (`myweatherhub`/`api`) instead of outdated names.

**Cross-cutting improvements:**

* Added a brief note about the optional `it-tools` container/resource in the dashboard, clarifying it can be ignored for modules 1–9. [[1]](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192R117-R146) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)
* Added a note about health endpoints visibility and reiterated working directory requirements for Azure deployment steps. [[1]](diffhunk://#diff-4012c5a7c65dba898ba85d4e4eda83f6a88b51a270b824ea197510acabab8192R102-R105) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)

**Open questions and recommendations:**

* Identified open questions about empty test files, AI dependencies, and extra containers for future consideration. [[1]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L196-R207) [[2]](diffhunk://#diff-ec52c526e99dc4767b61703f28becabe5d91afe4d53082ceff08c4559606ef47L170-R197)

These changes collectively improve the workshop experience by making instructions clearer, reducing ambiguity, and ensuring the documentation matches the actual implementation.