### PR TITLE
Replaced Swagger UI references with OpenAPI document links 

### DIFF
--- a/workshop/2-servicedefaults.md
+++ b/workshop/2-servicedefaults.md
@@ -63,9 +63,9 @@
      - Click `Start` to start and debug both projects.
    - Visual Studio Code: Run the `Api` and `MyWeatherHub` projects using the `Run and Debug` panel. We have provided a `launch.json` file with the necessary configurations to run both.
 1. Test the application by navigating to the following URLs:
-   - [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
+   - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API OpenAPI document
    - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
-1. You should see the Swagger UI for the API and the MyWeatherHub home page.
+1. You should see the OpenAPI document (JSON) for the API and the MyWeatherHub home page.
 1. You can also view the health checks for the API by navigating to [https://localhost:7032/health](https://localhost:7032/health).
 1. You can also view the health checks for the MyWeatherHub by navigating to [https://localhost:7274/health](https://localhost:7274/health).
 1. View the logs in the terminal to see the health checks and other telemetry data such as resiliency with Polly:

--- a/workshop/localization/es/2-servicedefaults.md
+++ b/workshop/localization/es/2-servicedefaults.md
@@ -15,76 +15,75 @@
 
 1. Agrega un nuevo proyecto a la solución llamado `ServiceDefaults`:
 
-	- Haz clic derecho en la solución y selecciona `Agregar` > `Nuevo proyecto`.
-	- Selecciona la plantilla de proyecto `.NET Aspire Service Defaults`.
-	- Nombra el proyecto `ServiceDefaults`.
-	- Haz clic en `Siguiente` > `Crear`.
+ - Haz clic derecho en la solución y selecciona `Agregar` > `Nuevo proyecto`.
+ - Selecciona la plantilla de proyecto `.NET Aspire Service Defaults`.
+ - Nombra el proyecto `ServiceDefaults`.
+ - Haz clic en `Siguiente` > `Crear`.
 
-	*Visual Studio*
-	![Cuadro de diálogo de Visual Studio para agregar un proyecto de valores predeterminados del servicio](./../../media/vs-add-servicedefaults.png)
+ *Visual Studio*
+ ![Cuadro de diálogo de Visual Studio para agregar un proyecto de valores predeterminados del servicio](./../../media/vs-add-servicedefaults.png)
 
-	*Visual Studio Code*
-	![Cuadro de diálogo de Visual Studio Code para agregar un proyecto de valores predeterminados del servicio](./../../media/vsc-add-servicedefaults.png)
-
+ *Visual Studio Code*
+ ![Cuadro de diálogo de Visual Studio Code para agregar un proyecto de valores predeterminados del servicio](./../../media/vsc-add-servicedefaults.png)
 
 ### Línea de comandos
 
 1. Crea un nuevo proyecto utilizando el comando `dotnet new aspire-servicedefaults`:
 
-	```bash
-	dotnet new aspire-servicedefaults -n ServiceDefaults
-	```
+ ```bash
+ dotnet new aspire-servicedefaults -n ServiceDefaults
+ ```
 
 ## Configurar los valores predeterminados del servicio
 
 1. Agrega una referencia al proyecto `ServiceDefaults` en los proyectos `Api` y `MyWeatherHub`:
 
-	- Haz clic derecho en el proyecto `Api` y selecciona `Agregar` > `Referencia`.
-		- Marca el proyecto `ServiceDefaults` y haz clic en `Aceptar`.
-	- Haz clic derecho en el proyecto `MyWeatherHub` y selecciona `Agregar` > `Referencia`.
-		- Marca el proyecto `ServiceDefaults` y haz clic en `Aceptar`.
+ - Haz clic derecho en el proyecto `Api` y selecciona `Agregar` > `Referencia`.
+  - Marca el proyecto `ServiceDefaults` y haz clic en `Aceptar`.
+ - Haz clic derecho en el proyecto `MyWeatherHub` y selecciona `Agregar` > `Referencia`.
+  - Marca el proyecto `ServiceDefaults` y haz clic en `Aceptar`.
 
-	> Consejo: En Visual Studio 2022, puedes arrastrar y soltar el proyecto sobre otro proyecto para agregar una referencia.
+ > Consejo: En Visual Studio 2022, puedes arrastrar y soltar el proyecto sobre otro proyecto para agregar una referencia.
 
 1. En los proyectos `Api` y `MyWeatherHub`, actualiza los archivos `Program.cs`, agregando la siguiente línea inmediatamente después de la línea `var builder = WebApplication.CreateBuilder(args);`:
 
-	```csharp
-	builder.AddServiceDefaults();
-	```
+ ```csharp
+ builder.AddServiceDefaults();
+ ```
 
 1. En los proyectos `Api` y `MyWeatherHub`, actualiza los archivos `Program.cs`, agregando la siguiente línea inmediatamente después de la línea `var app = builder.Build();`:
 
-	```csharp
-	app.MapDefaultEndpoints();
-	```
+ ```csharp
+ app.MapDefaultEndpoints();
+ ```
 
 ## Ejecutar la aplicación
 
 1. Ejecuta la aplicación utilizando una configuración de multiproyecto en Visual Studio o Visual Studio Code.
 
-	- Visual Studio: Haz clic derecho en la solución `MyWeatherHub` y ve a propiedades. Selecciona `Api` y `MyWeatherHub` como proyectos de inicio, selecciona `Aceptar`. 
-		- ![Propiedades de la solución de Visual Studio](./../../media/vs-multiproject.png)
-		- Haz clic en `Iniciar` para iniciar y depurar ambos proyectos.
-	- Visual Studio Code: Ejecuta los proyectos `Api` y `MyWeatherHub` utilizando el panel `Ejecutar y depurar`. Hemos proporcionado un archivo `launch.json` con las configuraciones necesarias para ejecutar ambos.
+ - Visual Studio: Haz clic derecho en la solución `MyWeatherHub` y ve a propiedades. Selecciona `Api` y `MyWeatherHub` como proyectos de inicio, selecciona `Aceptar`.
+  - ![Propiedades de la solución de Visual Studio](./../../media/vs-multiproject.png)
+  - Haz clic en `Iniciar` para iniciar y depurar ambos proyectos.
+ - Visual Studio Code: Ejecuta los proyectos `Api` y `MyWeatherHub` utilizando el panel `Ejecutar y depurar`. Hemos proporcionado un archivo `launch.json` con las configuraciones necesarias para ejecutar ambos.
 
 1. Prueba la aplicación navegando a las siguientes URL:
 
-	- [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
-	- [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
+ - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API (documento OpenAPI)
+ - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
 
-1. Deberías ver la interfaz de usuario de Swagger para la API y la página de inicio de MyWeatherHub.
+1. Deberías ver el documento OpenAPI (JSON) de la API y la página de inicio de MyWeatherHub.
 1. También puedes ver las comprobaciones de estado de la API navegando a [https://localhost:7032/health](https://localhost:7032/health).
 1. También puedes ver las comprobaciones de estado de MyWeatherHub navegando a [https://localhost:7274/health](https://localhost:7274/health).
 1. Visualiza los registros en la terminal para ver las comprobaciones de estado y otros datos de telemetría, como la resiliencia con Polly:
 
-	```bash
-	Polly: Información: Intento de ejecución. Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '200', Manejado: 'False', Intento: '0', Tiempo de ejecución: '13.0649'
-	```
+ ```bash
+ Polly: Información: Intento de ejecución. Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '200', Manejado: 'False', Intento: '0', Tiempo de ejecución: '13.0649'
+ ```
 
 1. Haz clic en 5 ciudades diferentes y se lanzará un error "aleatorio". Verás la política de re-intento en acción.
 
-	```bash
-	Polly: Advertencia: Intento de ejecución. Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '500', Manejado: 'True', Intento: '0', Tiempo de ejecución: '9732.8258'
-	Polly: Advertencia: Se produjo un evento de resiliencia. Nombre del evento: 'OnRetry', Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '500'
-	System.Net.Http.HttpClient.NwsManager.ClientHandler: Información: Enviando solicitud HTTP GET http://localhost:5271/forecast/AKZ318
-	```
+ ```bash
+ Polly: Advertencia: Intento de ejecución. Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '500', Manejado: 'True', Intento: '0', Tiempo de ejecución: '9732.8258'
+ Polly: Advertencia: Se produjo un evento de resiliencia. Nombre del evento: 'OnRetry', Origen: '-standard//Standard-Retry', Clave de operación: '', Resultado: '500'
+ System.Net.Http.HttpClient.NwsManager.ClientHandler: Información: Enviando solicitud HTTP GET http://localhost:5271/forecast/AKZ318
+ ```

--- a/workshop/localization/fr/2-servicedefaults.md
+++ b/workshop/localization/fr/2-servicedefaults.md
@@ -15,25 +15,24 @@
 
 1. Ajoutez un nouveau projet à la solution appelé `ServiceDefaults`:
 
-	- Faites un clic droit sur la solution et sélectionnez `Add` > `New Project`.
-	- Sélectionnez le modèle de projet `.NET Aspire Service Defaults`.
-	- Nommé le projet `ServiceDefaults`.
-	- Cliquez `Next` > `Create`.
+ - Faites un clic droit sur la solution et sélectionnez `Add` > `New Project`.
+ - Sélectionnez le modèle de projet `.NET Aspire Service Defaults`.
+ - Nommé le projet `ServiceDefaults`.
+ - Cliquez `Next` > `Create`.
 
-	*Visual Studio*
-	![Boîte de dialogue Visual Studio pour ajouter un projet de valeurs par défaut du service](./../../media/vs-add-servicedefaults.png)
+ *Visual Studio*
+ ![Boîte de dialogue Visual Studio pour ajouter un projet de valeurs par défaut du service](./../../media/vs-add-servicedefaults.png)
 
-	*Visual Studio Code*
-	![Boîte de dialogue Visual Studio Code pour ajouter un projet de valeurs par défaut du service](./../../media/vsc-add-servicedefaults.png)
-
+ *Visual Studio Code*
+ ![Boîte de dialogue Visual Studio Code pour ajouter un projet de valeurs par défaut du service](./../../media/vsc-add-servicedefaults.png)
 
 ### Ligne de commande
 
 1. Créez un nouveau projet à l'aide de la commande`dotnet new aspire-servicedefaults`:
 
-	```bash
-	dotnet new aspire-servicedefaults -n ServiceDefaults
-	```
+ ```bash
+ dotnet new aspire-servicedefaults -n ServiceDefaults
+ ```
 
 ## Configurer les paramètres par défaut du service
 
@@ -44,50 +43,52 @@
    - Faites un clic droit sur le projet `MyWeatherHub` et sélectionnez `Add` > `Reference`.
      - Vérifiez le projet `ServiceDefaults` et cliquez sur `OK`.
 
-	> Conseil de pro: dans Visual Studio 2022, vous pouvez faire glisser et déposer le projet sur un autre projet pour ajouter une référence.
+ > Conseil de pro: dans Visual Studio 2022, vous pouvez faire glisser et déposer le projet sur un autre projet pour ajouter une référence.
 
 1. Dans les projets `Api` et `MyWeatherHub`, modifiez leurs fichiers `Program.cs`, en ajoutant la ligne suivante immédiatement après leur ligne `var builder = WebApplication.CreateBuilder(args);` :
-	
-	```csharp
-	builder.AddServiceDefaults();
-	```
+ 
+ ```csharp
+ builder.AddServiceDefaults();
+ ```
+
 1. Dans les projets `Api` et `MyWeatherHub`, modifiez leurs fichiers `Program.cs`, en ajoutant la ligne suivante immédiatement après leur ligne `var app = builder.Build();` :
 
-	```csharp
-	app.MapDefaultEndpoints();
-	```
+ ```csharp
+ app.MapDefaultEndpoints();
+ ```
 
 ## Exécutez l'application
 
 1. Exécutez l'application à l'aide d'une configuration de lancement multi-projets dans Visual Studio ou Visual Studio Code.
 
-  - Visual Studio : Faites un clic droit sur la solution `MyWeatherHub` et accédez aux propriétés. Sélectionnez « Api » et « MyWeatherHub » comme projets de démarrage, sélectionnez « OK ».
-    - ![Propriétés de la solution Visual Studio](./../../media/vs-multiproject.png)
-    - Cliquez sur « Start » pour démarrer et déboguer les deux projets.
-  - Visual Studio Code : exécutez les projets `Api` et `MyWeatherHub` à l'aide du panneau `Exécuter et déboguer`. Nous avons fourni un fichier « launch.json » avec les configurations nécessaires pour exécuter les deux.
+- Visual Studio : Faites un clic droit sur la solution `MyWeatherHub` et accédez aux propriétés. Sélectionnez « Api » et « MyWeatherHub » comme projets de démarrage, sélectionnez « OK ».
+  - ![Propriétés de la solution Visual Studio](./../../media/vs-multiproject.png)
+  - Cliquez sur « Start » pour démarrer et déboguer les deux projets.
+- Visual Studio Code : exécutez les projets `Api` et `MyWeatherHub` à l'aide du panneau `Exécuter et déboguer`. Nous avons fourni un fichier « launch.json » avec les configurations nécessaires pour exécuter les deux.
 
 1. Test the application by navigating to the following URLs:
 
-	- [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
-	- [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
+ - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API (OpenAPI document)
+ - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
 
-1. You should see the Swagger UI for the API and the MyWeatherHub home page.
+1. You should see the OpenAPI document (JSON) for the API and the MyWeatherHub home page.
 1. You can also view the health checks for the API by navigating to [https://localhost:7032/health](https://localhost:7032/health).
 1. You can also view the health checks for the MyWeatherHub by navigating to [https://localhost:7274/health](https://localhost:7274/health).
 1. View the logs in the terminal to see the health checks and other telemetry data such as resiliency with Polly:
 
-1. Vous devriez voir l'interface utilisateur Swagger pour l'API et la page d'accueil de MyWeatherHub.
+1. Vous devriez voir le document OpenAPI (JSON) de l'API et la page d'accueil de MyWeatherHub.
 1. Vous pouvez également afficher les Contrôles de santé de l'API en accédant à [https://localhost:7032/health](https://localhost:7032/health).
 1. Vous pouvez également afficher les Contrôles de santé de MyWeatherHub en accédant à [https://localhost:7274/health](https://localhost:7274/health).
 1. Consultez les journaux (logs) dans le terminal pour voir les contrôles de santé et d'autres données de télémétrie telles que la résilience avec Polly :
 
-	```bash
-	Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
-	```
+ ```bash
+ Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
+ ```
+
 1. Cliquez sur 5 villes différentes et une erreur "random" sera générée. Vous verrez la politique de nouvelle tentative de Polly en action.
 
-	```bash
-	Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
-	Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
-	System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
-	```
+ ```bash
+ Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
+ Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
+ System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
+ ```

--- a/workshop/localization/jp/2-servicedefaults.md
+++ b/workshop/localization/jp/2-servicedefaults.md
@@ -15,73 +15,74 @@
 
 1. `ServiceDefaults` という名前の新しいプロジェクトをソリューションに追加します：
 
-	- ソリューションを右クリックし、追加 > 新しいプロジェクトを選択します。
-	- `.NET Aspire Service Defaults` プロジェクトテンプレートを選択します。
-	- プロジェクトに `ServiceDefaults` という名前を付けます。
-	- `次へ` > `作成` をクリックします。
+ - ソリューションを右クリックし、追加 > 新しいプロジェクトを選択します。
+ - `.NET Aspire Service Defaults` プロジェクトテンプレートを選択します。
+ - プロジェクトに `ServiceDefaults` という名前を付けます。
+ - `次へ` > `作成` をクリックします。
 
-	*Visual Studio*
-	![Visual Studio での service defaults プロジェクトの追加ダイアログ](./../../media/vs-add-servicedefaults.png)
+ *Visual Studio*
+ ![Visual Studio での service defaults プロジェクトの追加ダイアログ](./../../media/vs-add-servicedefaults.png)
 
-	*Visual Studio Code*
-	![Visual Studio Code での service defaults プロジェクトの追加ダイアログ](./../../media/vsc-add-servicedefaults.png)
-
+ *Visual Studio Code*
+ ![Visual Studio Code での service defaults プロジェクトの追加ダイアログ](./../../media/vsc-add-servicedefaults.png)
 
 ### コマンドライン
 
 1. `dotnet new aspire-servicedefaults` コマンドを使用して新しいプロジェクトを作成します：
 
-	```bash
-	dotnet new aspire-servicedefaults -n ServiceDefaults
-	```
+ ```bash
+ dotnet new aspire-servicedefaults -n ServiceDefaults
+ ```
 
 ## Service Defaults の設定
 
 1. `Api` および `MyWeatherHub` プロジェクトに `ServiceDefaults` プロジェクトへの参照を追加します：
 
-	- `Api` プロジェクトを右クリックし、`追加` > `参照` を選択します。
-		- `ServiceDefaults` プロジェクトをチェックし、`OK` をクリックします。
-	- `MyWeatherHub` プロジェクトを右クリックし、`追加` > `参照` を選択します。
-		- `ServiceDefaults` プロジェクトをチェックし、`OK` をクリックします。
+ - `Api` プロジェクトを右クリックし、`追加` > `参照` を選択します。
+  - `ServiceDefaults` プロジェクトをチェックし、`OK` をクリックします。
+ - `MyWeatherHub` プロジェクトを右クリックし、`追加` > `参照` を選択します。
+  - `ServiceDefaults` プロジェクトをチェックし、`OK` をクリックします。
 
-	> プロのヒント: Visual Studio 2022では、プロジェクトを別のプロジェクトにドラッグ＆ドロップして参照を追加できます。
+ > プロのヒント: Visual Studio 2022では、プロジェクトを別のプロジェクトにドラッグ＆ドロップして参照を追加できます。
 
 1. `Api` および `MyWeatherHub` プロジェクトの両方で、`Program.cs` ファイルを更新し、以下の行を `var builder = WebApplication.CreateBuilder(args);` 行の直後に追加します：
-	
-	```csharp
-	builder.AddServiceDefaults();
-	```
+ 
+ ```csharp
+ builder.AddServiceDefaults();
+ ```
+
 1. `Api` および `MyWeatherHub` プロジェクトの両方で、`Program.cs` ファイルを更新し、`var app = builder.Build();` 行の直後に以下の行を追加します：
 
-	```csharp
-	app.MapDefaultEndpoints();
-	```
+ ```csharp
+ app.MapDefaultEndpoints();
+ ```
 
 ## アプリケーションの実行
 
 1. Visual Studio または Visual Studio Code でマルチプロジェクト起動構成を使用してアプリケーションを実行します。
-	- Visual Studio: `MyWeatherHub` ソリューションを右クリックしてプロパティに移動し、`Api` と `MyWeatherHub` をスタートアッププロジェクトとして選択し、`OK` をクリックします。
-		- ![Visual Studio ソリューション プロパティ](./../../media/vs-multiproject.png)
-		- `開始` をクリックして、両方のプロジェクトを開始およびデバッグします。
-	- Visual Studio Code: `Run and Debug` パネルを使用して `Api` および `MyWeatherHub` プロジェクトを実行します。必要な構成が含まれている `launch.json` ファイルを提供しています。
+ - Visual Studio: `MyWeatherHub` ソリューションを右クリックしてプロパティに移動し、`Api` と `MyWeatherHub` をスタートアッププロジェクトとして選択し、`OK` をクリックします。
+  - ![Visual Studio ソリューション プロパティ](./../../media/vs-multiproject.png)
+  - `開始` をクリックして、両方のプロジェクトを開始およびデバッグします。
+ - Visual Studio Code: `Run and Debug` パネルを使用して `Api` および `MyWeatherHub` プロジェクトを実行します。必要な構成が含まれている `launch.json` ファイルを提供しています。
 
 1. 次の URL に移動してアプリケーションをテストします：
 
-	- [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
-	- [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
+ - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API（OpenAPI ドキュメント）
+ - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
 
-1. API の Swagger UI および MyWeatherHub のホームページが表示されるはずです。
+1. API の OpenAPI ドキュメント（JSON）と MyWeatherHub のホームページが表示されるはずです。
 1. 次のURLに移動してAPIのヘルスチェックを表示できます：[https://localhost:7032/health](https://localhost:7032/health)
 1. 次のURLに移動してMyWeatherHubのヘルスチェックを表示できます：[https://localhost:7274/health](https://localhost:7274/health)
 1. ターミナルでログを表示して、ヘルスチェックや Polly を使用したレジリエンスなどのテレメトリデータを確認できます：
 
-	```bash
-	Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
-	```
+ ```bash
+ Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
+ ```
+
 1. 5つの異なる都市をクリックすると、「ランダム」エラーが発生します。これにより、Polly のリトライポリシーが機能しているのを確認できます。
 
-	```bash
-	Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
-	Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
-	System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
-	```
+ ```bash
+ Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
+ Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
+ System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
+ ```

--- a/workshop/localization/ko/2-servicedefaults.md
+++ b/workshop/localization/ko/2-servicedefaults.md
@@ -70,10 +70,10 @@
 
 1. 다음 URL로 이동하여 애플리케이션을 테스트합니다:
 
-    - [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
+    - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API (OpenAPI 문서)
     - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
 
-1. API에 대한 Swagger UI와 MyWeatherHub 홈페이지가 나타납니다.
+1. API의 OpenAPI 문서(JSON)와 MyWeatherHub 홈페이지가 나타납니다.
 1. [https://localhost:7032/health](https://localhost:7032/health)로 이동하여 API에 대한 상태 확인을 볼 수 있습니다.
 1. [https://localhost:7274/health](https://localhost:7274/health)로 이동하여 MyWeatherHub에 대한 상태 확인을 볼 수 있습니다.
 1. 터미널에서 로그를 확인하여 Polly와 같은 헬스 체크, 회복탄력성 및 기타 텔레메트리 데이터를 볼 수 있습니다:

--- a/workshop/localization/pt-br/2-servicedefaults.md
+++ b/workshop/localization/pt-br/2-servicedefaults.md
@@ -1,6 +1,7 @@
 # Padrões de Serviço (Service Defaults/Smart Defaults)
 
 ## Introdução
+
 .NET Aspire fornece um conjunto de padrões inteligentes para serviços que são comumente usados em aplicações .NET. Esses padrões são projetados para ajudá-lo a começar rapidamente e fornecer uma experiência consistente em diferentes tipos de aplicações. Isso inclui:
 
 - Telemetria: Métricas, Rastreamento, Log
@@ -14,72 +15,74 @@
 
 1. Adicione um novo projeto à solução chamado `ServiceDefaults`:
 
-	- Clique com o botão direito na solução e selecione `Add` > `New Project`.
-	- Selecione o modelo de projeto `.NET Aspire Service Defaults`.
-	- Nomeie o projeto como `ServiceDefaults`.
-	- Clique em `Next` > `Create`.
+ - Clique com o botão direito na solução e selecione `Add` > `New Project`.
+ - Selecione o modelo de projeto `.NET Aspire Service Defaults`.
+ - Nomeie o projeto como `ServiceDefaults`.
+ - Clique em `Next` > `Create`.
 
-	*Visual Studio*
-	![Janela do Visual Studio para adicionar um projeto de padrões de serviço](./../../media/vs-add-servicedefaults.png)
+ *Visual Studio*
+ ![Janela do Visual Studio para adicionar um projeto de padrões de serviço](./../../media/vs-add-servicedefaults.png)
 
-	*Visual Studio Code*
-	![Janela do Visual Studio Code para adicionar um projeto de padrões de serviço](./../../media/vsc-add-servicedefaults.png)
+ *Visual Studio Code*
+ ![Janela do Visual Studio Code para adicionar um projeto de padrões de serviço](./../../media/vsc-add-servicedefaults.png)
 
 ### Linha de Comando
 
 1. Crie um novo projeto usando o comando `dotnet new aspire-servicedefaults`:
 
-	```bash
-	dotnet new aspire-servicedefaults -n ServiceDefaults
-	```
+ ```bash
+ dotnet new aspire-servicedefaults -n ServiceDefaults
+ ```
 
 ## Configure o Padrões de Serviço
 
 1. Adicione uma referência ao projeto `ServiceDefaults` nos projetos `Api` e `MyWeatherHub`:
 
-	- Clique com o botão direito no projeto `Api` e selecione `Add` > `Reference`.
-		- Selecione o projeto `ServiceDefaults` e clique em `OK`.
-	- Clique com o botão direito no projeto `MyWeatherHub` e selecione `Add` > `Reference`.
-		- Selecione o projeto `ServiceDefaults` e clique em `OK`.
+ - Clique com o botão direito no projeto `Api` e selecione `Add` > `Reference`.
+  - Selecione o projeto `ServiceDefaults` e clique em `OK`.
+ - Clique com o botão direito no projeto `MyWeatherHub` e selecione `Add` > `Reference`.
+  - Selecione o projeto `ServiceDefaults` e clique em `OK`.
 
-	> Dica: No Visual Studio 2022, você pode arrastar e soltar o projeto em outro projeto para adicionar uma referência.
+ > Dica: No Visual Studio 2022, você pode arrastar e soltar o projeto em outro projeto para adicionar uma referência.
 1. Nos projetos `Api` e `MyWeatherHub`, atualize seus arquivos `Program.cs`, adicionando a seguinte linha imediatamente após a linha `var builder = WebApplication.CreateBuilder(args);`:
 
-	```csharp
-	builder.AddServiceDefaults();
-	```
+ ```csharp
+ builder.AddServiceDefaults();
+ ```
+
 1. Nos projetos `Api` e `MyWeatherHub`, atualize seus arquivos `Program.cs`, adicionando a seguinte linha imediatamente após a linha `var app = builder.Build();`:
 
-	```csharp
-	app.MapDefaultEndpoints();
-	```
+ ```csharp
+ app.MapDefaultEndpoints();
+ ```
 
 ## Execute a aplicação
 
 1. Execute a aplicação usando uma configuração de execução multiprojeto no Visual Studio ou Visual Studio Code.
 
-	- Visual Studio: Clique com o botão direito na solução `MyWeatherHub` e vá para propriedades. Selecione `Api` e `MyWeatherHub` como "startup projects", selecione `OK`.
-		- ![Propriedades da solução do Visual Studio](./../../media/vs-multiproject.png)
-		- Clique em `Start` para começar e depurar ambos os projetos.
-	- Visual Studio Code: Execute os projetos `Api` e `MyWeatherHub` usando o painel `Run and Debug`. Fornecemos um arquivo `launch.json` com as configurações necessárias para executar ambos.
+ - Visual Studio: Clique com o botão direito na solução `MyWeatherHub` e vá para propriedades. Selecione `Api` e `MyWeatherHub` como "startup projects", selecione `OK`.
+  - ![Propriedades da solução do Visual Studio](./../../media/vs-multiproject.png)
+  - Clique em `Start` para começar e depurar ambos os projetos.
+ - Visual Studio Code: Execute os projetos `Api` e `MyWeatherHub` usando o painel `Run and Debug`. Fornecemos um arquivo `launch.json` com as configurações necessárias para executar ambos.
 
 1. Teste a aplicação navegando para os seguintes URLs:
 
-	- [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
-	- [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
+ - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API (documento OpenAPI)
+ - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
 
-1. Você deve conseguir accessar a API e a página inicial do MyWeatherHub no Swagger.
+1. Você deve ver o documento OpenAPI (JSON) da API e a página inicial do MyWeatherHub.
 1. Você também pode accessar as verificações de saúde (health checks) da API navegando para [https://localhost:7032/health](https://localhost:7032/health).
 1. Você também pode visualizar as verificações de saúde (health checks) do MyWeatherHub navegando para [https://localhost:7274/health](https://localhost:7274/health).
 1. Veja os logs no terminal para ver as verificações de saúde (health checks) e outros dados de telemetria, como resiliência com Polly:
 
-	```bash
-	Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
-	```
+ ```bash
+ Polly: Information: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '13.0649'
+ ```
+
 1. Clique em 5 cidades diferentes e um erro "aleatório" será lançado. Você verá a política de nova tentativa do Polly em ação.
 
-	```bash
-	Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
-	Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
-	System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
-	```
+ ```bash
+ Polly: Warning: Execution attempt. Source: '-standard//Standard-Retry', Operation Key: '', Result: '500', Handled: 'True', Attempt: '0', Execution Time: '9732.8258'
+ Polly: Warning: Resilience event occurred. EventName: 'OnRetry', Source: '-standard//Standard-Retry', Operation Key: '', Result: '500'
+ System.Net.Http.HttpClient.NwsManager.ClientHandler: Information: Sending HTTP request GET http://localhost:5271/forecast/AKZ318
+ ```

--- a/workshop/localization/zh-cn/2-servicedefaults.md
+++ b/workshop/localization/zh-cn/2-servicedefaults.md
@@ -63,9 +63,9 @@
      - 点击 `Start` 来启动和调试这两个项目.
    - Visual Studio Code: 使用 `Run and Debug` 面板来运行 `Api` 和 `MyWeatherHub` 项目。我们提供了包含所需配置的 `launch.json` 文件来支持运行这两个项目。
 2. 通过导航到以下 URL 来测试应用程序:
-   - [https://localhost:7032/swagger/index.html](https://localhost:7032/swagger/index.html) - API
+   - [https://localhost:7032/openapi/v1.json](https://localhost:7032/openapi/v1.json) - API（OpenAPI 文档）
    - [https://localhost:7274/](https://localhost:7274/) - MyWeatherHub
-3. 您应该会看到 API 的 Swagger UI 和 MyWeatherHub 主页。
+3. 您应该会看到 API 的 OpenAPI 文档（JSON）和 MyWeatherHub 主页。
 4. 您还可以通过导航到 [https://localhost:7032/health](https://localhost:7032/health).
 5. 您还可以通过导航到 [https://localhost:7274/health](https://localhost:7274/health).
 6. 查看终端中的日志以查看运行状况检查和其他遥测数据，例如 Polly 的弹性：


### PR DESCRIPTION
Replaced Swagger UI references with OpenAPI document links in Module 2 across English and localized docs. Code exposes OpenAPI via MapOpenApi() in Development. Verified no remaining Swagger references.

Fixes #119