### PR TITLE
Update Dependabot for checkpoint projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,31 @@ updates:
     directory: "/complete"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-02-ServiceDefaults/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-03-Dashboard-AppHost/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-04-ServiceDiscovery/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-05-Integrations/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-06-Telemetry/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-07-Database/code"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/workshop/Lesson-08-Integration-Testing/code"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds automated dependency update configurations for several workshop lesson directories using Dependabot. These changes ensure that NuGet dependencies in each lesson's code are checked and updated weekly.

**Dependabot configuration updates:**

* Added weekly NuGet dependency update schedules for the following lesson directories:  
  - `Lesson-02-ServiceDefaults/code`  
  - `Lesson-03-Dashboard-AppHost/code`  
  - `Lesson-04-ServiceDiscovery/code`  
  - `Lesson-05-Integrations/code`  
  - `Lesson-06-Telemetry/code`  
  - `Lesson-07-Database/code`  
  - `Lesson-08-Integration-Testing/code`  
  in `.github/dependabot.yml`